### PR TITLE
Add rate limit error handling.

### DIFF
--- a/lib-gphotos/client.go
+++ b/lib-gphotos/client.go
@@ -119,7 +119,8 @@ func (client *Client) UploadFile(filePath string, pAlbumID ...string) (*photosli
 		}).Do()
 		if err != nil {
 			// handle rate limit error by sleeping and retrying
-			if batchResponse.ServerResponse.HTTPStatusCode == 429 {
+			if batchResponse != nil && batchResponse.ServerResponse != nil &&
+				batchResponse.ServerResponse.HTTPStatusCode == 429 {
 				after, err := strconv.ParseInt(batchResponse.ServerResponse.Header.Get("Retry-After"), 10, 64)
 				if err != nil || after == 0 {
 					after = 10

--- a/lib-gphotos/client.go
+++ b/lib-gphotos/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/palantir/stacktrace"
 	"golang.org/x/oauth2"
 
+	"google.golang.org/api/googleapi"
 	photoslibrary "google.golang.org/api/photoslibrary/v1"
 )
 
@@ -119,9 +120,8 @@ func (client *Client) UploadFile(filePath string, pAlbumID ...string) (*photosli
 		}).Do()
 		if err != nil {
 			// handle rate limit error by sleeping and retrying
-			if batchResponse != nil && batchResponse.ServerResponse != nil &&
-				batchResponse.ServerResponse.HTTPStatusCode == 429 {
-				after, err := strconv.ParseInt(batchResponse.ServerResponse.Header.Get("Retry-After"), 10, 64)
+			if err.(*googleapi.Error).Code == 429 {
+				after, err := strconv.ParseInt(err.(*googleapi.Error).Header.Get("Retry-After"), 10, 64)
 				if err != nil || after == 0 {
 					after = 10
 				}

--- a/lib-gphotos/client.go
+++ b/lib-gphotos/client.go
@@ -105,6 +105,7 @@ func (client *Client) UploadFile(filePath string, pAlbumID ...string) (*photosli
 	}
 
 	retry := true
+	retryCount := 0
 	for retry != false {
 		retry = false
 		batchResponse, err := client.MediaItems.BatchCreate(&photoslibrary.BatchCreateMediaItemsRequest{
@@ -122,6 +123,13 @@ func (client *Client) UploadFile(filePath string, pAlbumID ...string) (*photosli
 				log.Printf("Rate limit reached, sleeping for 10 seconds...")
 				time.Sleep(10 * time.Second)
 				retry = true
+				retryCount++
+				continue
+			} else if retryCount < 3 {
+				log.Printf("Error during upload, sleeping for 10 seconds before retrying...")
+				time.Sleep(10 * time.Second)
+				retry = true
+				retryCount++
 				continue
 			}
 			return nil, stacktrace.Propagate(err, "failed adding media %s", filename)


### PR DESCRIPTION
Gracefully handles rate limiting in the Photos API.
https://github.com/nmrshll/gphotos-uploader-cli/issues/22