### PR TITLE
support retry on `/v1/upload` as well

### DIFF
--- a/lib-gphotos/client.go
+++ b/lib-gphotos/client.go
@@ -1,8 +1,8 @@
 package gphotos
 
 import (
+	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -27,6 +27,55 @@ type Client struct {
 	*photoslibrary.Service
 	*http.Client
 	token *oauth2.Token
+}
+
+func parse429Header(header http.Header) int64 {
+	after, err := strconv.ParseInt(header.Get("Retry-After"), 10, 32)
+	if err != nil {
+		return 0
+	}
+	return after
+}
+
+func retry(attempts int, sleep time.Duration, fn func() error) error {
+	var err error
+	for ; attempts > 0; attempts-- {
+		err = fn()
+		if err != nil {
+			switch err.(type) {
+			case stopStatus:
+				// fn() returned critical stop
+				return err.(stopStatus).error
+			case retryStatus:
+				errRetry := err.(retryStatus)
+				if errRetry.retryAfter != 0 {
+					time.Sleep(time.Duration(errRetry.retryAfter) * time.Second)
+				} else {
+					time.Sleep(sleep)
+				}
+				// exponential backoff
+				sleep *= 2
+				continue
+			default:
+				// fn() returned unknown err
+				return err
+			}
+		}
+		// fn() was ok return nil no retry
+		return nil
+	}
+	// return the final error
+	return err
+}
+
+type stopStatus struct {
+	error
+}
+
+type retryStatus struct {
+	error
+	// retry after seconds
+	retryAfter int
 }
 
 // Token returns the value of the token used by the gphotos Client
@@ -57,8 +106,9 @@ func NewClient(oauthHTTPClient *http.Client, maybeToken ...*oauth2.Token) (*Clie
 }
 
 // GetUploadToken sends the media and returns the UploadToken.
-func (client *Client) GetUploadToken(r io.Reader, filename string) (token string, err error) {
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s/uploads", basePath, apiVersion), r)
+func (client *Client) GetUploadToken(r *os.File, filename string) (token string, err error) {
+	// NoopCloser prevents body from closing so we can retry
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s%s/uploads", basePath, apiVersion), ioutil.NopCloser(r))
 	if err != nil {
 		return "", err
 	}
@@ -66,18 +116,43 @@ func (client *Client) GetUploadToken(r io.Reader, filename string) (token string
 	req.Header.Add("X-Goog-Upload-File-Name", filename)
 	req.Header.Set("X-Goog-Upload-Protocol", "raw")
 
-	res, err := client.Client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer res.Body.Close()
+	// start retry
+	var res *http.Response
+	retryErr := retry(3, 1, func() error {
+		r.Seek(0, 0)
+		res, err = client.Client.Do(req)
+		if err != nil {
+			// internal error just stop
+			return stopStatus{error: err}
+		}
+		if res == nil {
+			return stopStatus{error: errors.New("empty response")}
+		}
+		if res.StatusCode != 200 {
+			switch res.StatusCode {
+			case 429:
+				after := parse429Header(res.Header)
+				log.Printf("429 throttle waiting %d sec", after)
+				return retryStatus{retryAfter: int(after)}
 
+			default:
+				// for now we'll just quit. in future we can retry other errors
+				return nil
+			}
+		}
+		// we're ok res will have response body
+		return nil
+	})
+	if retryErr != nil {
+		return "", retryErr
+	}
+	// end retry
+	defer res.Body.Close()
 	b, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}
-	uploadToken := string(b)
-	return uploadToken, nil
+	return string(b), nil
 }
 
 // Upload actually uploads the media and activates it on google photos
@@ -105,11 +180,9 @@ func (client *Client) UploadFile(filePath string, pAlbumID ...string) (*photosli
 		return nil, stacktrace.Propagate(err, "failed getting uploadToken for %s", filename)
 	}
 
-	retry := true
-	retryCount := 0
-	for retry != false {
-		retry = false
-		batchResponse, err := client.MediaItems.BatchCreate(&photoslibrary.BatchCreateMediaItemsRequest{
+	var batchResponse *photoslibrary.BatchCreateMediaItemsResponse
+	retryErr := retry(3, 1, func() error {
+		batchResponse, err = client.MediaItems.BatchCreate(&photoslibrary.BatchCreateMediaItemsRequest{
 			AlbumId: albumID,
 			NewMediaItems: []*photoslibrary.NewMediaItem{
 				&photoslibrary.NewMediaItem{
@@ -121,36 +194,29 @@ func (client *Client) UploadFile(filePath string, pAlbumID ...string) (*photosli
 		if err != nil {
 			// handle rate limit error by sleeping and retrying
 			if err.(*googleapi.Error).Code == 429 {
-				after, err := strconv.ParseInt(err.(*googleapi.Error).Header.Get("Retry-After"), 10, 64)
-				if err != nil || after == 0 {
-					after = 10
-				}
+				after := parse429Header(err.(*googleapi.Error).Header)
 				log.Printf("Rate limit reached, sleeping for %d seconds...", after)
-				time.Sleep(time.Duration(after) * time.Second)
-				retry = true
-				continue
-			} else if retryCount < 3 {
-				log.Printf("Error during upload, sleeping for 10 seconds before retrying...")
-				time.Sleep(10 * time.Second)
-				retry = true
-				retryCount++
-				continue
+				return retryStatus{retryAfter: int(after), error: err}
 			}
-			return nil, stacktrace.Propagate(err, "failed adding media %s", filename)
+			log.Printf("Unknown error uploading will retry")
+			return retryStatus{error: err}
 		}
-
-		if batchResponse == nil || len(batchResponse.NewMediaItemResults) != 1 {
-			return nil, stacktrace.NewError("len(batchResults) should be 1")
-		}
-		result := batchResponse.NewMediaItemResults[0]
-		if result.Status.Message != "OK" {
-			return nil, stacktrace.NewError("status message should be OK, found: %s", result.Status.Message)
-		}
-
-		log.Printf("%s uploaded successfully as %s", filename, result.MediaItem.Id)
-		return result.MediaItem, nil
+		return nil
+	})
+	if retryErr != nil {
+		return nil, stacktrace.Propagate(err, "failed adding media %s", filename)
 	}
-	return nil, nil
+
+	if batchResponse == nil || len(batchResponse.NewMediaItemResults) != 1 {
+		return nil, stacktrace.NewError("len(batchResults) should be 1")
+	}
+	result := batchResponse.NewMediaItemResults[0]
+	if result.Status.Message != "OK" {
+		return nil, stacktrace.NewError("status message should be OK, found: %s", result.Status.Message)
+	}
+
+	log.Printf("%s uploaded successfully as %s", filename, result.MediaItem.Id)
+	return result.MediaItem, nil
 }
 
 func (client *Client) AlbumByName(name string) (album *photoslibrary.Album, found bool, err error) {


### PR DESCRIPTION
Fixes issue with nmrshll/gphotos-uploader-cli/pull/45 -- 429s occur

I've added retry support to both `v1/upload` and `batchCreate` by refactoring retry logic into a `retry()` function. 

`retry()` retries `fn()` depending on its return
`retryStatus` --- will retry gain after `retryStatus.retryAfter` or exponential backoff if unset
`stopStatus` -- will quit retry with error
`nil`  -- will quit with success