### PR TITLE
Add support for "Success" status message

### DIFF
--- a/lib-gphotos/client.go
+++ b/lib-gphotos/client.go
@@ -143,8 +143,8 @@ func (client *Client) UploadFile(filePath string, pAlbumID ...string) (*photosli
 			return nil, stacktrace.NewError("len(batchResults) should be 1")
 		}
 		result := batchResponse.NewMediaItemResults[0]
-		if result.Status.Message != "OK" {
-			return nil, stacktrace.NewError("status message should be OK, found: %s", result.Status.Message)
+		if result.Status.Message != "OK" && result.Status.Message != "Success" {
+			return nil, stacktrace.NewError("status message should be OK/Success, found: %s", result.Status.Message)
 		}
 
 		log.Printf("%s uploaded successfully as %s", filename, result.MediaItem.Id)


### PR DESCRIPTION
Adds support for "Success" status message, along with "OK", for successful uploads. This is based on this comment: https://github.com/nmrshll/gphotos-uploader-cli/issues/64#issuecomment-505246310